### PR TITLE
feat: add ArgoCD sync-wave annotations for proper deployment order

### DIFF
--- a/.github/workflows/validate-challenges.yaml
+++ b/.github/workflows/validate-challenges.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - '**/challenge.yaml'
+      - '**/manifests/*.yaml'
+      - '**/policies/*.yaml'
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -21,7 +23,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v46
         with:
-          files: '**/challenge.yaml'
+          files: |
+            **/challenge.yaml
+            **/manifests/*.yaml
+            **/policies/*.yaml
           dir_names: true
           dir_names_max_depth: 1
 

--- a/access-pending/manifests/deployment.yaml
+++ b/access-pending/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: startup-app
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/access-pending/manifests/namespace.yaml
+++ b/access-pending/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: access-pending
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/access-pending/manifests/role-binding.yaml
+++ b/access-pending/manifests/role-binding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: startup-check-binding
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 subjects:
   - kind: ServiceAccount
     name: startup-checker

--- a/access-pending/manifests/role.yaml
+++ b/access-pending/manifests/role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: startup-check-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 rules:
   - apiGroups: [""]
     resources: ["pods"]

--- a/access-pending/manifests/service-account.yaml
+++ b/access-pending/manifests/service-account.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: startup-checker
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/access-pending/policies/restrict-modifications.yaml
+++ b/access-pending/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/bad-config/manifests/configmap-updated.yaml
+++ b/bad-config/manifests/configmap-updated.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 data:
   config.json: |
     {

--- a/bad-config/manifests/configmap.yaml
+++ b/bad-config/manifests/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 data:
   config.json: |
     {

--- a/bad-config/manifests/deployment.yaml
+++ b/bad-config/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-app
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 2
   selector:

--- a/bad-config/manifests/namespace.yaml
+++ b/bad-config/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bad-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/bad-config/manifests/service.yaml
+++ b/bad-config/manifests/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: web-app-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   selector:
     app: web-app

--- a/bad-config/policies/restrict-modifications.yaml
+++ b/bad-config/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-config-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/job-failed/manifests/cronjob.yaml
+++ b/job-failed/manifests/cronjob.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: data-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   schedule: "0 2 * * *"
   jobTemplate:

--- a/job-failed/manifests/job.yaml
+++ b/job-failed/manifests/job.yaml
@@ -4,6 +4,8 @@ metadata:
   name: data-processor-manual
   labels:
     app: data-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   activeDeadlineSeconds: 30
   template:

--- a/job-failed/manifests/namespace.yaml
+++ b/job-failed/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: job-failed
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/job-failed/policies/restrict-modifications.yaml
+++ b/job-failed/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-job-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/lost-logs/manifests/deployment.yaml
+++ b/lost-logs/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-app
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/lost-logs/manifests/namespace.yaml
+++ b/lost-logs/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lost-logs
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/lost-logs/policies/restrict-modifications.yaml
+++ b/lost-logs/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-logging-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/out-of-space/manifests/namespace.yaml
+++ b/out-of-space/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: out-of-space
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/out-of-space/manifests/service.yaml
+++ b/out-of-space/manifests/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   clusterIP: None  # Headless service for StatefulSet
   selector:

--- a/out-of-space/manifests/statefulset.yaml
+++ b/out-of-space/manifests/statefulset.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: postgres
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   serviceName: postgres-service
   replicas: 3  # Problem: 3 replicas with ReadWriteOnce volumes

--- a/out-of-space/policies/restrict-modifications.yaml
+++ b/out-of-space/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-storage-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/partial-outage/manifests/backend-deployment.yaml
+++ b/partial-outage/manifests/backend-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backend
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/partial-outage/manifests/backend-service.yaml
+++ b/partial-outage/manifests/backend-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: backend
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   selector:
     app: backend

--- a/partial-outage/manifests/frontend-deployment.yaml
+++ b/partial-outage/manifests/frontend-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 2
   selector:

--- a/partial-outage/manifests/frontend-service.yaml
+++ b/partial-outage/manifests/frontend-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   selector:
     app: frontend

--- a/partial-outage/manifests/namespace.yaml
+++ b/partial-outage/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: partial-outage
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/partial-outage/manifests/network-policy.yaml
+++ b/partial-outage/manifests/network-policy.yaml
@@ -4,6 +4,8 @@ metadata:
   name: deny-all
   labels:
     validate: "false"
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   podSelector: {}
   policyTypes:

--- a/partial-outage/policies/avoid-deleting-egress-policy.yaml
+++ b/partial-outage/policies/avoid-deleting-egress-policy.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: avoid-deny-delete-networkpolicy
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   rules:

--- a/partial-outage/policies/labels-protection.yaml
+++ b/partial-outage/policies/labels-protection.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: protect-app-labels
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   rules:
     - name: block-label-change

--- a/pod-evicted/manifests/deployment.yaml
+++ b/pod-evicted/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: data-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/pod-evicted/manifests/namespace.yaml
+++ b/pod-evicted/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pod-evicted
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/pod-evicted/policies/restrict-modifications.yaml
+++ b/pod-evicted/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-resource-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/privilege-denied/manifests/deployment.yaml
+++ b/privilege-denied/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: legacy-app
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/privilege-denied/manifests/namespace.yaml
+++ b/privilege-denied/manifests/namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: privilege-denied
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   labels:
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest

--- a/privilege-denied/policies/protect-pss-labels.yaml
+++ b/privilege-denied/policies/protect-pss-labels.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: protect-pss-labels-privilege-denied
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: Enforce
   background: false

--- a/privilege-denied/policies/restrict-modifications.yaml
+++ b/privilege-denied/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-security-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/probes-drift/manifests/namespace.yaml
+++ b/probes-drift/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: probes-drift
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/probes-drift/manifests/notify-service.yaml
+++ b/probes-drift/manifests/notify-service.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: notify-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/probes-drift/policies/no-deletion-deployment.yaml
+++ b/probes-drift/policies/no-deletion-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: no-deletion-deployment
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   rules:

--- a/secret-not-shared/manifests/deployment.yaml
+++ b/secret-not-shared/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   selector:

--- a/secret-not-shared/manifests/namespace.yaml
+++ b/secret-not-shared/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secret-not-shared
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/secret-not-shared/manifests/secret.yaml
+++ b/secret-not-shared/manifests/secret.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: database-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 type: Opaque
 stringData:
   DATABASE_HOST: "postgres.default.svc.cluster.local"

--- a/secret-not-shared/policies/restrict-modifications.yaml
+++ b/secret-not-shared/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-secret-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true

--- a/traffic-jam/manifests/deployment.yaml
+++ b/traffic-jam/manifests/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 2
   selector:

--- a/traffic-jam/manifests/ingress.yaml
+++ b/traffic-jam/manifests/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: api-ingress
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   rules:
     - host: api.example.com

--- a/traffic-jam/manifests/namespace.yaml
+++ b/traffic-jam/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traffic-jam
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/traffic-jam/manifests/service.yaml
+++ b/traffic-jam/manifests/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   selector:
     app: api-service  # Correct selector matching deployment

--- a/traffic-jam/policies/restrict-modifications.yaml
+++ b/traffic-jam/policies/restrict-modifications.yaml
@@ -2,6 +2,8 @@ apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: restrict-ingress-modifications
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   validationFailureAction: enforce
   background: true


### PR DESCRIPTION
## Summary
- Fix deployment race conditions where Kyverno policies blocked resource creation
- Add sync-wave annotations to ensure proper deployment order across all challenges
- Add `namespace.yaml` to all challenges for proper ArgoCD lifecycle management
- Add CI validation for sync-wave annotations

## Problem
When starting a challenge like `privilege-denied`, the Kyverno policy was being applied before the namespace was created, causing:
```
admission webhook "validate.kyverno.svc-fail" denied the request:
resource Namespace//privilege-denied was blocked due to the following policies
```

## Solution
Use ArgoCD sync-wave annotations to control deployment order:

| Wave | Resources | Purpose |
|------|-----------|---------|
| 0 | `namespace.yaml` | Created first |
| 1 | `manifests/*.yaml` | After namespace exists |
| 2 | `policies/*.yaml` | After all resources exist |

## Changes
- **52 files modified** across 11 challenges
- **10 new `namespace.yaml`** files created
- **CI validation** updated to enforce sync-wave rules

## Test plan
- [x] Run `node .github/scripts/validate-challenges.js` on all challenges
- [ ] Test `kubeasy challenge start privilege-denied`
- [ ] Test `kubeasy challenge reset privilege-denied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)