### PR TITLE
feat!: migrate to remote JSON schema validation

### DIFF
--- a/.github/CHALLENGE_TEMPLATE.md
+++ b/.github/CHALLENGE_TEMPLATE.md
@@ -6,7 +6,7 @@ Use this template to create new challenges for Kubeasy.
 
 ```
 your-challenge-name/
-├── challenge.yaml      # Required: metadata + validations
+├── challenge.yaml      # Required: metadata + objectives
 ├── manifests/          # Required: broken K8s manifests
 │   ├── deployment.yaml
 │   ├── service.yaml
@@ -28,9 +28,10 @@ description: |
 
 theme: category-name  # rbac-security, networking, volumes-secrets, resources-scaling, monitoring-debugging
 difficulty: medium    # easy | medium | hard
-estimated_time: 15    # Minutes (5-60 recommended)
+type: fix             # fix | build | migrate
+estimatedTime: 15     # Minutes (5-60 recommended)
 
-initial_situation: |
+initialSituation: |
   Describe what the user will find.
   What's deployed? What state is it in?
   Focus on observations, not explanations.
@@ -40,12 +41,12 @@ objective: |
   State the goal, not the method.
   "Make the app work" not "Fix the ConfigMap"
 
-validations:
+objectives:
   - key: unique-identifier
     title: "Outcome-Based Title"
     description: "What this validation checks (not how to fix it)"
     order: 1
-    type: status  # status | log | event | metrics | rbac | connectivity
+    type: status  # status | log | event | metrics | connectivity
     spec:
       target:
         kind: Pod
@@ -70,7 +71,7 @@ validations:
       sinceSeconds: 120
 ```
 
-## Validation Type Examples
+## Objective Type Examples
 
 ### Status (check resource conditions)
 ```yaml
@@ -122,22 +123,10 @@ spec:
     kind: Pod
     labelSelector:
       app: my-app
-  metricChecks:
-    - metric: restartCount
+  checks:
+    - field: restartCount
       operator: LessThan  # LessThan, GreaterThan, Equals
       value: 3
-```
-
-### RBAC (test permissions)
-```yaml
-type: rbac
-spec:
-  serviceAccountName: my-sa
-  requiredPermissions:
-    - resource: pods
-      verb: list
-    - resource: secrets
-      verb: get
 ```
 
 ### Connectivity (HTTP checks)
@@ -159,11 +148,11 @@ Before submitting:
 
 - [ ] Description describes symptoms, NOT the cause
 - [ ] Objective states the goal, NOT the solution
-- [ ] Validation titles don't reveal what to fix
+- [ ] Objective titles don't reveal what to fix
 - [ ] Manifests deploy in broken state
 - [ ] Kyverno policies prevent bypasses (image changes, resource deletion)
 - [ ] Challenge works in Kind cluster
-- [ ] Intended solution passes all validations
+- [ ] Intended solution passes all objectives
 
 ## Anti-Patterns to Avoid
 
@@ -171,7 +160,7 @@ Before submitting:
 - Bad: "Fix the memory limit configuration"
 - Good: "Make the pod run stably"
 
-**Don't be too specific in validations:**
+**Don't be too specific in objectives:**
 - Bad: `title: "Memory Limit Set to 256Mi"`
 - Good: `title: "Stable Operation"`
 

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "challenges-sync",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "challenges-sync",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@octokit/rest": "^20.1.1",
-        "@supabase/supabase-js": "^2.49.8",
+        "ajv": "^8.17.1",
         "js-yaml": "^4.1.0"
       }
     },
@@ -26,6 +26,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -157,102 +158,20 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
-    "node_modules/@supabase/auth-js": {
-      "version": "2.69.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
-      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
-      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
-      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
-      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.18.0"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.49.8",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.8.tgz",
-      "integrity": "sha512-zzBQLgS/jZs7btWcIAc7V5yfB+juG7h0AXxKowMJuySsO5vK+F7Vp+HCa07Z+tu9lZtr3sT9fofkc86bdylmtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.69.1",
-        "@supabase/functions-js": "2.4.4",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.19.4",
-        "@supabase/realtime-js": "2.11.2",
-        "@supabase/storage-js": "2.7.1"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/argparse": {
@@ -271,6 +190,28 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -283,6 +224,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -291,64 +238,24 @@
         "wrappy": "1"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -6,6 +6,7 @@
   "license": "ISC",
   "description": "Kubeasy challenge synchronization tool - syncs challenges to the API",
   "dependencies": {
+    "ajv": "^8.17.1",
     "js-yaml": "^4.1.0",
     "@octokit/rest": "^20.1.1"
   }

--- a/.github/scripts/sync.js
+++ b/.github/scripts/sync.js
@@ -7,8 +7,8 @@ const { validateChallenge } = require("./validation");
 const API_URL = process.env.API_URL
 const API_TOKEN = process.env.API_TOKEN;
 
-// Valid validation types for objectives
-const VALID_TYPES = ["status", "log", "event", "metrics", "rbac", "connectivity"];
+// Valid validation types for objectives (matches remote schema)
+const VALID_TYPES = ["status", "log", "event", "metrics", "connectivity"];
 
 if (!API_TOKEN) {
   console.error("Missing API_TOKEN env variable");
@@ -54,34 +54,34 @@ function formatDisplayName(name) {
 }
 
 /**
- * Extracts objectives from validations array in challenge data
+ * Extracts objectives from objectives array in challenge data
  */
-function extractObjectives(folder, validations) {
-  if (!validations || !Array.isArray(validations)) {
+function extractObjectives(folder, objectivesData) {
+  if (!objectivesData || !Array.isArray(objectivesData)) {
     return [];
   }
 
   const objectives = [];
 
-  for (const validation of validations) {
-    const key = validation.key;
+  for (const objective of objectivesData) {
+    const key = objective.key;
     if (!key) {
-      console.warn(`   ⚠️  ${folder}/challenge.yaml: validation missing 'key' field`);
+      console.warn(`   ⚠️  ${folder}/challenge.yaml: objective missing 'key' field`);
       continue;
     }
 
-    const type = validation.type;
+    const type = objective.type;
     if (!type || !VALID_TYPES.includes(type)) {
-      console.warn(`   ⚠️  ${folder}/challenge.yaml: validation '${key}' has invalid type '${type}'`);
+      console.warn(`   ⚠️  ${folder}/challenge.yaml: objective '${key}' has invalid type '${type}'`);
       continue;
     }
 
     objectives.push({
       objectiveKey: key,
-      title: validation.title || formatDisplayName(key),
-      description: validation.description || null,
+      title: objective.title || formatDisplayName(key),
+      description: objective.description || null,
       category: type,
-      displayOrder: validation.order || 0,
+      displayOrder: objective.order || 0,
     });
   }
 
@@ -117,8 +117,8 @@ async function loadChallenge(folder) {
     throw new Error(`Validation errors:\n${validationErrors.join('\n')}`);
   }
 
-  // Extract objectives from validations in challenge.yaml
-  const objectives = extractObjectives(folder, challenge.validations);
+  // Extract objectives from objectives array in challenge.yaml
+  const objectives = extractObjectives(folder, challenge.objectives);
 
   return {
     slug: folder,
@@ -126,11 +126,12 @@ async function loadChallenge(folder) {
     description: challenge.description,
     theme: challenge.theme,
     difficulty: challenge.difficulty,
-    estimatedTime: challenge.estimated_time,
-    initialSituation: challenge.initial_situation,
+    type: challenge.type || "fix",
+    estimatedTime: challenge.estimatedTime,
+    initialSituation: challenge.initialSituation,
     objective: challenge.objective,
-    ofTheWeek: challenge.of_the_week || false,
-    starterFriendly: challenge.starter_friendly || false,
+    ofTheWeek: challenge.ofTheWeek || false,
+    starterFriendly: challenge.starterFriendly || false,
     objectives,
   };
 }

--- a/.github/scripts/validate-challenges.js
+++ b/.github/scripts/validate-challenges.js
@@ -136,8 +136,8 @@ async function validateSingleChallenge(challengeFolder) {
     const warnings = [];
     
     // Check for recommended fields
-    if (!challengeData.initial_situation || challengeData.initial_situation.trim().length < 10) {
-      warnings.push("Consider adding a more detailed initial_situation");
+    if (!challengeData.initialSituation || challengeData.initialSituation.trim().length < 10) {
+      warnings.push("Consider adding a more detailed initialSituation");
     }
     
     if (!challengeData.objective || challengeData.objective.trim().length < 10) {
@@ -145,8 +145,8 @@ async function validateSingleChallenge(challengeFolder) {
     }
     
     // Check estimated time is reasonable
-    if (challengeData.estimated_time < 5 || challengeData.estimated_time > 120) {
-      warnings.push(`Estimated time (${challengeData.estimated_time}min) seems unusual. Consider reviewing.`);
+    if (challengeData.estimatedTime < 5 || challengeData.estimatedTime > 120) {
+      warnings.push(`Estimated time (${challengeData.estimatedTime}min) seems unusual. Consider reviewing.`);
     }
     
     // Check if manifests directory exists
@@ -181,9 +181,10 @@ async function validateSingleChallenge(challengeFolder) {
     
     console.log(`✅ Challenge ${challengeFolder} is valid`);
     console.log(`   Title: "${challengeData.title}"`);
+    console.log(`   Type: ${challengeData.type}`);
     console.log(`   Theme: ${challengeData.theme}`);
     console.log(`   Difficulty: ${challengeData.difficulty}`);
-    console.log(`   Estimated time: ${challengeData.estimated_time} minutes`);
+    console.log(`   Estimated time: ${challengeData.estimatedTime} minutes`);
     
     return true;
     

--- a/CHALLENGE_GUIDELINES.md
+++ b/CHALLENGE_GUIDELINES.md
@@ -58,14 +58,14 @@ Describe what the user will find, not what's wrong:
 
 **Bad**:
 ```yaml
-initial_situation: |
+initialSituation: |
   The deployment has incorrect resource limits set to 10Mi memory,
   which is too low for the application.
 ```
 
 **Good**:
 ```yaml
-initial_situation: |
+initialSituation: |
   A data processing application is deployed as a single pod.
   The pod starts successfully but gets killed after a few seconds.
   It enters a CrashLoopBackOff state and keeps restarting.
@@ -90,30 +90,30 @@ objective: |
 
 ---
 
-## Validation Design
+## Objective Design
 
-Validations verify the solution is correct. **They should confirm the fix worked, not guide users to the fix.**
+Objectives verify the solution is correct. **They should confirm the fix worked, not guide users to the fix.**
 
 ### Golden Rule
 
-> **A validation should check the outcome, not the specific implementation.**
+> **An objective should check the outcome, not the specific implementation.**
 
-### Validation Types
+### Objective Types
 
-Each validation is defined in the `validations` section of `challenge.yaml`:
+Each objective is defined in the `objectives` section of `challenge.yaml`:
 
 ```yaml
-validations:
+objectives:
   - key: unique-identifier
     title: "User-Friendly Title"
-    description: "What this validation checks"
+    description: "What this objective checks"
     order: 1
-    type: status|log|event|metrics|rbac|connectivity
+    type: status|log|event|metrics|connectivity
     spec:
       # Type-specific configuration
 ```
 
-### Available Validation Types
+### Available Objective Types
 
 | Type | Purpose | Example Use Case |
 |------|---------|------------------|
@@ -121,12 +121,11 @@ validations:
 | `log` | Find strings in container logs | "Connected to database", "Server started" |
 | `event` | Detect forbidden K8s events | No OOMKilled, no Evicted events |
 | `metrics` | Check pod/deployment metrics | Restart count < 3, replicas >= 2 |
-| `rbac` | Test ServiceAccount permissions | Can create pods, can list secrets |
 | `connectivity` | HTTP connectivity tests | Service responds with 200 |
 
-### Validation Examples
+### Objective Examples
 
-#### Status Validation
+#### Status Objective
 ```yaml
 - key: pod-ready-check
   title: "Pod Ready"
@@ -143,7 +142,7 @@ validations:
         status: "True"
 ```
 
-#### Log Validation
+#### Log Objective
 ```yaml
 - key: database-connection
   title: "Database Connected"
@@ -160,7 +159,7 @@ validations:
     sinceSeconds: 120
 ```
 
-#### Event Validation
+#### Event Objective
 ```yaml
 - key: no-crashes
   title: "No Crash Events"
@@ -179,7 +178,7 @@ validations:
     sinceSeconds: 300
 ```
 
-#### Metrics Validation
+#### Metrics Objective
 ```yaml
 - key: low-restarts
   title: "Stable Operation"
@@ -191,34 +190,18 @@ validations:
       kind: Pod
       labelSelector:
         app: my-app
-    metricChecks:
-      - metric: restartCount
+    checks:
+      - field: restartCount
         operator: LessThan
         value: 3
 ```
 
-#### RBAC Validation
-```yaml
-- key: sa-permissions
-  title: "ServiceAccount Permissions"
-  description: "The service account must have required permissions"
-  order: 5
-  type: rbac
-  spec:
-    serviceAccountName: my-service-account
-    requiredPermissions:
-      - resource: pods
-        verb: list
-      - resource: secrets
-        verb: get
-```
-
-#### Connectivity Validation
+#### Connectivity Objective
 ```yaml
 - key: service-reachable
   title: "Service Connectivity"
   description: "The service must be reachable from within the cluster"
-  order: 6
+  order: 5
   type: connectivity
   spec:
     sourcePod:
@@ -232,7 +215,7 @@ validations:
 
 ---
 
-## Validation Anti-Patterns
+## Objective Anti-Patterns
 
 ### Don't Reveal the Solution
 
@@ -296,7 +279,7 @@ Use Kyverno policies to prevent users from bypassing the challenge entirely (e.g
 
 - Container images (prevent replacing the app)
 - Critical volume mounts (prevent removing problematic configs)
-- Essential labels (ensure validations can find resources)
+- Essential labels (ensure objectives can find resources)
 
 ### Example Policy
 
@@ -342,7 +325,7 @@ Each challenge folder should contain:
 
 ```
 challenge-name/
-├── challenge.yaml      # Metadata, description, AND validations
+├── challenge.yaml      # Metadata, description, AND objectives
 ├── manifests/          # Initial Kubernetes manifests (broken state)
 │   ├── deployment.yaml
 │   ├── service.yaml
@@ -362,8 +345,9 @@ description: |
   It was working fine yesterday, but now Kubernetes keeps killing it.
 theme: resources-scaling
 difficulty: easy
-estimated_time: 15
-initial_situation: |
+type: fix
+estimatedTime: 15
+initialSituation: |
   A data processing application is deployed as a single pod.
   The pod starts successfully but after a few seconds gets killed.
   It enters a CrashLoopBackOff state and keeps restarting.
@@ -372,7 +356,7 @@ objective: |
   Fix the pod so it can run without being evicted.
   Understand why Kubernetes is killing the application.
 
-validations:
+objectives:
   - key: pod-running
     title: "Pod Ready"
     description: "The data-processor pod must be running and healthy"
@@ -413,8 +397,8 @@ Before submitting a challenge:
 - [ ] The issue manifests as described (app fails as expected)
 - [ ] The intended solution fixes the problem
 - [ ] Alternative valid solutions also work (if applicable)
-- [ ] Validations pass only when the issue is actually fixed
-- [ ] Validations don't reveal the solution in titles/descriptions
+- [ ] Objectives pass only when the issue is actually fixed
+- [ ] Objectives don't reveal the solution in titles/descriptions
 - [ ] Kyverno policies prevent obvious bypasses
 - [ ] Description maintains mystery about the root cause
 - [ ] Estimated time is realistic
@@ -425,7 +409,7 @@ Before submitting a challenge:
 
 1. **Solution in the title**: "Fix Memory Limit" → "Stable Operation"
 2. **Too much context**: Explaining why something is broken
-3. **Overly specific validations**: Checking exact config values
+3. **Overly specific objectives**: Checking exact config values
 4. **Missing bypass protection**: Users can just delete and recreate resources
 5. **Unrealistic scenarios**: Problems that would never happen in production
 6. **Too many hints**: Step-by-step instructions instead of a goal

--- a/access-pending/challenge.yaml
+++ b/access-pending/challenge.yaml
@@ -4,8 +4,9 @@ description: |
   Dig into what happens before the first log line ever appears.
 theme: rbac-security
 difficulty: hard
-estimated_time: 15
-initial_situation: |
+type: fix
+estimatedTime: 15
+initialSituation: |
   A recent deployment was pushed using the usual CI process, with a custom image and a startup probe.
   The application doesn't seem to be running as expected.
   You're now responsible for diagnosing and unlocking the situation — but without modifying the image or bypassing any critical settings.
@@ -14,7 +15,7 @@ objective: |
   Something is blocking the startup sequence — your job is to identify the root cause
   and adjust the current configuration so the rollout can complete successfully.
 
-validations:
+objectives:
   - key: pod-ready-check
     title: "Pod Ready"
     description: "The startup-app pod must be running and in Ready state"

--- a/bad-config/challenge.yaml
+++ b/bad-config/challenge.yaml
@@ -4,9 +4,10 @@ description: |
   The pods are living in the past.
 theme: pods-containers
 difficulty: easy
-estimated_time: 15
-starter_friendly: true
-initial_situation: |
+type: fix
+estimatedTime: 15
+starterFriendly: true
+initialSituation: |
   A web application is deployed with its configuration in a ConfigMap.
   The team updated the ConfigMap to enable a new feature flag.
   Checking the ConfigMap shows the new values are definitely there.
@@ -15,7 +16,7 @@ objective: |
   Make sure configuration changes actually reach the running application.
   Future config updates shouldn't silently fail like this.
 
-validations:
+objectives:
   - key: pod-ready-check
     title: "Pod Ready"
     description: "The web-app pod must be running and in Ready state"

--- a/job-failed/challenge.yaml
+++ b/job-failed/challenge.yaml
@@ -4,8 +4,9 @@ description: |
   It used to work fine, but now it times out and gets killed by Kubernetes.
 theme: jobs-cronjobs
 difficulty: medium
-estimated_time: 15
-initial_situation: |
+type: fix
+estimatedTime: 15
+initialSituation: |
   A CronJob that processes data every night has been consistently failing.
   The job starts running but gets terminated before completion.
   The processing logic hasn't changed, but something in the cluster configuration is causing issues.
@@ -13,7 +14,7 @@ objective: |
   Investigate why the nightly job keeps failing and restore normal operation.
   The processing workflow should complete successfully every night.
 
-validations:
+objectives:
   - key: job-completion-check
     title: "Job Completed"
     description: "The data-processor Job must reach 'Complete' status"

--- a/lost-logs/challenge.yaml
+++ b/lost-logs/challenge.yaml
@@ -4,9 +4,10 @@ description: |
   Some containers show logs, others don't.
 theme: monitoring-debugging
 difficulty: easy
-estimated_time: 15
-starter_friendly: true
-initial_situation: |
+type: fix
+estimatedTime: 15
+starterFriendly: true
+initialSituation: |
   A multi-container pod is deployed with a main application and a sidecar logger.
   The main application runs fine and you can see its logs with kubectl logs.
   However, the sidecar container writes logs to a file (/var/log/app.log) instead of stdout.
@@ -16,7 +17,7 @@ objective: |
   Fix the logging configuration so all container logs are visible via kubectl logs.
   Ensure logs are written to stdout/stderr following 12-factor app principles.
 
-validations:
+objectives:
   - key: check-logger-stdout
     title: "Sidecar Logs"
     description: "The logger sidecar must capture and output both 'Application log entry' and 'Logger sidecar' messages"

--- a/out-of-space/challenge.yaml
+++ b/out-of-space/challenge.yaml
@@ -4,8 +4,9 @@ description: |
   They all want the same thing, but apparently they can't all have it.
 theme: volumes-secrets
 difficulty: medium
-estimated_time: 20
-initial_situation: |
+type: fix
+estimatedTime: 20
+initialSituation: |
   A PostgreSQL StatefulSet was running fine with a single replica.
   To improve availability, the team scaled it to 3 replicas.
   The first pod is Running normally, but pods 2 and 3 are stuck in Pending.
@@ -14,7 +15,7 @@ objective: |
   Figure out why scaling breaks the deployment and get things working again.
   Not every problem is solved by throwing more replicas at it.
 
-validations:
+objectives:
   - key: all-postgres-pods-ready
     title: "All Pods Ready"
     description: "All postgres pods must be in Ready state"
@@ -38,10 +39,10 @@ validations:
       target:
         kind: StatefulSet
         name: postgres
-      metricChecks:
-        - metric: readyReplicas
+      checks:
+        - field: readyReplicas
           operator: Equals
           value: 3
-        - metric: availableReplicas
+        - field: availableReplicas
           operator: Equals
           value: 3

--- a/partial-outage/challenge.yaml
+++ b/partial-outage/challenge.yaml
@@ -3,14 +3,15 @@ description: The frontend app is up — but some users report failures. It's not
   Investigate the cluster's configuration before the incident spreads.
 theme: networking
 difficulty: easy
-estimated_time: 10
-starter_friendly: true
-initial_situation: |
+type: fix
+estimatedTime: 10
+starterFriendly: true
+initialSituation: |
   A frontend Deployment with 2 replicas and a backend Deployment with 1 replica are deployed in the same namespace.
   A NetworkPolicy is defined, but users still report issues — possibly related to intra-cluster communication.
 objective: Ensure the frontend can successfully communicate with the backend over HTTP, while keeping traffic restricted.
 
-validations:
+objectives:
   - key: frontend-ready-check
     title: "Frontend Ready"
     description: "The frontend pod must be running and in Ready state"

--- a/pod-evicted/challenge.yaml
+++ b/pod-evicted/challenge.yaml
@@ -4,9 +4,10 @@ description: |
   It was working fine yesterday, but now Kubernetes keeps killing it.
 theme: resources-scaling
 difficulty: easy
-estimated_time: 15
-starter_friendly: true
-initial_situation: |
+type: fix
+estimatedTime: 15
+starterFriendly: true
+initialSituation: |
   A data processing application is deployed as a single pod.
   The pod starts successfully but after a few seconds gets OOMKilled (Out of Memory).
   It enters a CrashLoopBackOff state and keeps restarting.
@@ -16,7 +17,7 @@ objective: |
   Fix the resource configuration so the pod can run without being evicted.
   Understand the difference between requests and limits, and how Kubernetes manages resources.
 
-validations:
+objectives:
   - key: pod-running-check
     title: "Pod Ready"
     description: "The data-processor pod must be running and in Ready state"
@@ -57,7 +58,7 @@ validations:
         kind: Pod
         labelSelector:
           app: data-processor
-      metricChecks:
-        - metric: restartCount
+      checks:
+        - field: restartCount
           operator: LessThan
           value: 3

--- a/privilege-denied/challenge.yaml
+++ b/privilege-denied/challenge.yaml
@@ -4,8 +4,9 @@ description: |
   Security policies have been enforced, and the deployment needs updating.
 theme: rbac-security
 difficulty: medium
-estimated_time: 20
-initial_situation: |
+type: fix
+estimatedTime: 20
+initialSituation: |
   A legacy application was deployed and worked fine initially.
   After implementing Pod Security Standards at the cluster level, the pod fails to start.
   The error message shows: "Error: container has runAsNonRoot and image will run as root".
@@ -15,7 +16,7 @@ objective: |
   Update the deployment's SecurityContext to comply with Pod Security Standards.
   Make the application run as a non-root user and use a read-only root filesystem.
 
-validations:
+objectives:
   - key: pod-ready-check
     title: "Pod Ready"
     description: "The legacy-app pod must be running and in Ready state"

--- a/probes-drift/challenge.yaml
+++ b/probes-drift/challenge.yaml
@@ -2,8 +2,9 @@ title: Probes Drift
 description: The app works perfectly in local tests. In Kubernetes? It never stays up long enough to find out.
 theme: monitoring-debugging
 difficulty: medium
-estimated_time: 15
-initial_situation: |
+type: fix
+estimatedTime: 15
+initialSituation: |
   A notification service was deployed with health checks configured.
   The container starts, begins initialization, but Kubernetes keeps restarting it in a loop.
   There's no application error in the logs - it just keeps getting killed mid-startup.
@@ -11,7 +12,7 @@ objective: |
   Stop the crash loop and get the service running.
   The app is fine - something about how Kubernetes checks its health isn't right.
 
-validations:
+objectives:
   - key: app-ready-check
     title: "Pod Ready Check"
     description: "The notify-service pod must be in Ready state with healthy liveness and readiness probes"

--- a/secret-not-shared/challenge.yaml
+++ b/secret-not-shared/challenge.yaml
@@ -4,8 +4,9 @@ description: |
   The Secret exists, but the pod doesn't have access to it.
 theme: volumes-secrets
 difficulty: medium
-estimated_time: 20
-initial_situation: |
+type: fix
+estimatedTime: 20
+initialSituation: |
   A new microservice was deployed that needs to connect to a PostgreSQL database.
   The database credentials are stored in a Kubernetes Secret.
   The Secret exists and contains the correct username and password.
@@ -15,7 +16,7 @@ objective: |
   Fix the deployment configuration so the pod can access the database credentials from the Secret.
   The application expects credentials as environment variables: DATABASE_HOST, DATABASE_USER, DATABASE_PASSWORD.
 
-validations:
+objectives:
   - key: pod-ready-check
     title: "Pod Ready"
     description: "The api-service pod must be running and in Ready state"

--- a/traffic-jam/challenge.yaml
+++ b/traffic-jam/challenge.yaml
@@ -4,8 +4,9 @@ description: |
   Something invisible is blocking the traffic.
 theme: networking
 difficulty: hard
-estimated_time: 20
-initial_situation: |
+type: fix
+estimatedTime: 20
+initialSituation: |
   A microservice was deployed behind an Ingress controller for external access.
   The pods are Running and respond perfectly when accessed directly.
   The Service configuration looks correct and matches the pod labels.
@@ -14,7 +15,7 @@ objective: |
   Find what's breaking the traffic flow from Ingress to pods.
   Everything looks right on paper - dig deeper.
 
-validations:
+objectives:
   - key: pods-ready-check
     title: "API Pods Ready"
     description: "All API pods must be running and in Ready state"
@@ -54,7 +55,5 @@ validations:
           app: api-service
       targets:
         - url: "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local"
-          headers:
-            Host: "api.example.com"
           expectedStatusCode: 200
           timeoutSeconds: 5


### PR DESCRIPTION
## Summary

- Migrate challenge validation to use remote JSON schema from `https://kubeasy.dev/api/schemas/challenge` as single source of truth
- Convert all challenge.yaml files from snake_case to camelCase field naming
- Rename `validations` array to `objectives` to match the remote schema
- Remove local schema definition from validation scripts

## Breaking Changes

This is a breaking change for challenge.yaml format:
- `estimated_time` → `estimatedTime`
- `initial_situation` → `initialSituation`
- `of_the_week` → `ofTheWeek`
- `starter_friendly` → `starterFriendly`
- `validations` → `objectives`
- Metrics spec: `metricChecks`/`metric` → `checks`/`field`
- Removed `rbac` validation type
- Removed `headers` from connectivity spec

## Changes

### Scripts
- **validation.js**: Fetches remote schema and validates with Ajv (2020-12 draft)
- **sync.js**: Reads camelCase fields, removed `rbac` from valid types
- **validate-challenges.js**: Uses camelCase field names
- **package.json**: Added `ajv` dependency

### Challenge files (11 files)
All migrated to new camelCase format with `objectives` instead of `validations`

### Documentation
- **CHALLENGE_TEMPLATE.md**: Updated examples with new format
- **CHALLENGE_GUIDELINES.md**: Updated documentation and examples

## Test plan

- [x] Run `node .github/scripts/validate-challenges.js` on all challenges
- [x] All 11 challenges pass validation against remote schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)