### PR TITLE
fix(pod-evicted): preserve mystery and fix broken liveness probe

### DIFF
--- a/pod-evicted/challenge.yaml
+++ b/pod-evicted/challenge.yaml
@@ -9,13 +9,12 @@ estimatedTime: 15
 starterFriendly: true
 initialSituation: |
   A data processing application is deployed as a single pod.
-  The pod starts successfully but after a few seconds gets OOMKilled (Out of Memory).
+  The pod starts but keeps crashing after a few seconds.
   It enters a CrashLoopBackOff state and keeps restarting.
-  The application code hasn't changed, but Kubernetes is now enforcing resource limits.
-  The pod's memory usage exceeds the configured limit, causing eviction.
+  The application code hasn't changed - it was working fine in the previous environment.
 objective: |
-  Fix the resource configuration so the pod can run without being evicted.
-  Understand the difference between requests and limits, and how Kubernetes manages resources.
+  Investigate why the pod keeps crashing and fix it so it runs stably.
+  The pod should stay running without being killed by the system.
 
 objectives:
   - key: pod-running-check

--- a/pod-evicted/manifests/deployment.yaml
+++ b/pod-evicted/manifests/deployment.yaml
@@ -52,13 +52,7 @@ spec:
             limits:
               cpu: "200m"
               memory: "50Mi"
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - "ps aux | grep python3 | grep -v grep"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
       restartPolicy: Always


### PR DESCRIPTION
## Summary

- Remove explicit mentions of OOMKilled/memory limits from description
- Rewrite initialSituation to describe symptoms only, not causes  
- Remove broken liveness probe (`ps` command not available in `python:3.11-slim`)
- Add `PYTHONUNBUFFERED=1` for real-time log visibility

## Context

Challenge review identified that `pod-evicted` was scoring 10/20 due to:
1. **Description spoiling the solution** - explicitly mentioned "OOMKilled", "memory limit"
2. **Broken liveness probe** - used `ps aux` which doesn't exist in the slim image, causing confusing failures even after fixing memory

## Test plan

- [ ] Deploy challenge with `kubeasy challenge start pod-evicted`
- [ ] Verify pod crashes without revealing cause in description
- [ ] Verify `kubectl describe pod` shows OOMKilled reason
- [ ] Verify logs are visible in real-time
- [ ] Fix memory limit and verify challenge passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)