### PR TITLE
fix: env-config validation type and partial-outage bypass protection

### DIFF
--- a/env-config/challenge.yaml
+++ b/env-config/challenge.yaml
@@ -38,7 +38,7 @@ objectives:
     title: "App Running"
     description: "The application must be running and healthy"
     order: 2
-    type: condition
+    type: status
     spec:
       target:
         kind: Pod

--- a/env-config/manifests/deployment.yaml
+++ b/env-config/manifests/deployment.yaml
@@ -40,13 +40,6 @@ spec:
                 echo "App is healthy - $(date)"
                 sleep 30
               done
-          # NOTE: Environment variables need to be added here from a ConfigMap
-          # env:
-          #   - name: APP_NAME
-          #     valueFrom:
-          #       configMapKeyRef:
-          #         name: app-config
-          #         key: app_name
           resources:
             requests:
               cpu: "25m"

--- a/partial-outage/policies/avoid-deleting-egress-policy.yaml
+++ b/partial-outage/policies/avoid-deleting-egress-policy.yaml
@@ -1,17 +1,23 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: avoid-deny-delete-networkpolicy
+  name: protect-deny-all-networkpolicy
   annotations:
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
+  background: false
   rules:
     - name: block-delete-deny-all
       match:
-        resources:
-          kinds: ["NetworkPolicy"]
-          names: ["deny-all"]
+        any:
+          - resources:
+              kinds:
+                - NetworkPolicy
+              names:
+                - deny-all
+              operations:
+                - DELETE
       validate:
-        message: "You are not allowed to delete the default NetworkPolicy"
+        message: "Deleting the deny-all NetworkPolicy is not allowed. Add ingress rules instead."
         deny: {}


### PR DESCRIPTION
## Summary

Final fixes for the two remaining "needs work" challenges.

### env-config (14/20 → ~17/20)

**Issues fixed**:
1. Validation type `condition` is invalid → changed to `status`
2. Deployment contained spoiler comment showing exact solution → removed

### partial-outage (12/20 → ~16/20)

**Issue fixed**:
- Kyverno policy didn't properly block DELETE operations
- Users could bypass by running `kubectl delete networkpolicy deny-all`
- Fixed with correct syntax using `operations: ["DELETE"]` in match block

### Impact

After this PR + #18:
- All remaining 16 challenges should be functional
- No more "BROKEN" status challenges
- Expected average score: ~17/20

## Test plan

- [ ] env-config: Verify CLI can validate (no "unknown type" error)
- [ ] partial-outage: Verify `kubectl delete networkpolicy deny-all` is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)